### PR TITLE
last char truncated bug fix (issue #10)

### DIFF
--- a/R/treetag.R
+++ b/R/treetag.R
@@ -341,7 +341,7 @@ treetag <- function(file, treetagger="kRp.env", rm.sgml=TRUE, lang="kRp.env",
       # TreeTagger can produce mixed encoded results if fed with UTF-8 in Latin1 mode
       tknz.results <- iconv(tknz.results, from="UTF-8", to=input.enc)
       message(paste0("Assuming '", input.enc, "' as encoding for the input file. If the results turn out to be erroneous, check the file for invalid characters, e.g. em.dashes or fancy quotes, and/or consider setting 'encoding' manually."))
-      cat(paste(tknz.results, collapse="\n"), file=tknz.tempfile)
+      cat(paste(tknz.results, collapse="\n"), "\n", file=tknz.tempfile)
       if(!isTRUE(debug)){
         on.exit(unlink(tknz.tempfile), add=TRUE)
       } else {}


### PR DESCRIPTION
only [one line](https://github.com/unDocUMeantIt/koRpus/blob/master/R/treetag.R#L344) of code changed in pull request to address #10 where last char is being truncated in `koRpus::treetag()`

```
doc <- "The quick brown fox jumped over the lazy dog"

# pre bug fix in R/treetag.R
koRpus::treetag(doc, treetagger = "manual", format = "obj", 
                encoding = "UTF-8", lang = "en", TT.tknz = FALSE, 
                TT.options = list(path = "/u/application/TreeTagger", preset = "en"))
#    token tag lemma lttr      wclass                                             desc stop stem
# 1    The  DT   the    3  determiner                                       Determiner   NA   NA
# 2  quick  JJ quick    5   adjective                                        Adjective   NA   NA
# 3  brown  JJ brown    5   adjective                                        Adjective   NA   NA
# 4    fox  NN   fox    3        noun                           Noun, singular or mass   NA   NA
# 5 jumped VBD  jump    6        verb                      Verb, past tense of "to be"   NA   NA
# 6   over  IN  over    4 preposition         Preposition or subordinating conjunction   NA   NA
# 7    the  DT   the    3  determiner                                       Determiner   NA   NA
# 8   lazy  JJ  lazy    4   adjective                                        Adjective   NA   NA
# 9     do VBP    do    2        verb Verb, non-3rd person singular present of "to be"   NA   NA

# post bug fix in R/treetag.R
koRpus::treetag(doc, treetagger = "manual", format = "obj", 
                encoding = "UTF-8", lang = "en", TT.tknz = FALSE, 
                TT.options = list(path = "/u/application/TreeTagger", preset = "en"))
#    token tag lemma lttr      wclass                                     desc stop stem
# 1    The  DT   the    3  determiner                               Determiner   NA   NA
# 2  quick  JJ quick    5   adjective                                Adjective   NA   NA
# 3  brown  JJ brown    5   adjective                                Adjective   NA   NA
# 4    fox  NN   fox    3        noun                   Noun, singular or mass   NA   NA
# 5 jumped VBD  jump    6        verb              Verb, past tense of "to be"   NA   NA
# 6   over  IN  over    4 preposition Preposition or subordinating conjunction   NA   NA
# 7    the  DT   the    3  determiner                               Determiner   NA   NA
# 8   lazy  JJ  lazy    4   adjective                                Adjective   NA   NA
# 9    dog  NN   dog    3        noun                   Noun, singular or mass   NA   NA
```