### PR TITLE
newline to end of tknz.results cat to avoid dropping last char in treetag

### DIFF
--- a/R/treetag.R
+++ b/R/treetag.R
@@ -348,7 +348,7 @@ treetag <- function(file, treetagger="kRp.env", rm.sgml=TRUE, lang="kRp.env",
       # TreeTagger can produce mixed encoded results if fed with UTF-8 in Latin1 mode
       tknz.results <- iconv(tknz.results, from="UTF-8", to=input.enc)
       on.exit(message(paste0("Assuming '", input.enc, "' as encoding for the input file. If the results turn out to be erroneous, check the file for invalid characters, e.g. em.dashes or fancy quotes, and/or consider setting 'encoding' manually.")))
-      cat(paste(tknz.results, collapse="\n"), file=tknz.tempfile)
+      cat(paste(tknz.results, collapse="\n"), "\n", file=tknz.tempfile)
       if(!isTRUE(debug)){
         on.exit(unlink(tknz.tempfile), add=TRUE)
       } else {}


### PR DESCRIPTION
per issue #11 of dropping last char in treetagger function when `TT.tknz=FALSE`